### PR TITLE
Fix typo, duplicate word

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ including many excellent designs, and selected one winner,
 Daniel Dinu, and Dmitry Khovratovich from University of Luxembourg.
 <br/>
 <br/> 
-We recommend that use you use Argon2 rather than legacy algorithms.
+We recommend that you use Argon2 rather than legacy algorithms.
 You'll find the specifications and reference code just below.  <br/>
 <br/>
 </section>


### PR DESCRIPTION
The [German Wikipedia Entry](https://de.wikipedia.org/wiki/Password_Hashing_Competition#Argon2) already contains the quote, including its typo :smile: 

I have no idea if you even take PRs but let's try this anyways.